### PR TITLE
Muda a opção --dev para --group dev (novo padrão do poetry)

### DIFF
--- a/docs/continua.md
+++ b/docs/continua.md
@@ -34,11 +34,11 @@ O isort irá modificar o seu código ordenando as importações alfabéticamente
 Execute o comando abaixo:
 
 ```
-poetry add isort --dev
+poetry add isort --group dev
 ```
 
 !!! info
-    Utilizamos a opção --dev pois é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
+    Utilizamos a opção --group dev pois é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
 
 #### Configuração
 
@@ -73,11 +73,11 @@ O black é um formatador automático de código, ele irá modificar o seu códig
 Execute o comando abaixo:
 
 ```
-poetry add black --dev
+poetry add black --group dev
 ```
 
 !!! info
-    Utilizamos a opção --dev pois é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
+    Utilizamos a opção --group dev pois é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
 
 #### Configuração
 
@@ -114,11 +114,11 @@ Esta ferramenta será integrada ao editor, dessa maneira, ao salvar o arquivo, t
 Execute o comando abaixo:
 
 ```
-poetry add flake8 --dev
+poetry add flake8 --group dev
 ```
 
 !!! info
-    Utilizamos a opção --dev pois é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
+    Utilizamos a opção --group dev pois é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
 
 #### Como executar
 

--- a/docs/projeto.md
+++ b/docs/projeto.md
@@ -143,11 +143,11 @@ Esta ferramenta ajuda a fazer estes testes de uma maneira mais simples.
 Execute o comando:
 
 ```
-poetry add httpie --dev
+poetry add httpie --group dev
 ```
 
 !!! info
-		Utilizamos a opção --dev pois o httpie é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
+		Utilizamos a opção --group dev pois o httpie é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
 
 #### Vamos verificar se deu tudo certo?
 Execute o seguinte comando:
@@ -211,10 +211,10 @@ Já dizia Michael C. Feathers, "Um código sem testes, é um código ruim. Não 
 Execute o comando:
 
 ```
-poetry add pytest --dev
+poetry add pytest --group dev
 ```
 !!! info
- 	Utilizamos a opção --dev pois o pytest é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
+ 	Utilizamos a opção --group dev pois o pytest é um pacote necessário somente durante o desenvolvimento e não durante a execução do software.
 
 #### Vamos verificar se deu tudo certo?
 


### PR DESCRIPTION
O Poetry está mudando a forma de adicionar as dependências, agora para adicionar uma dependências de desenvolvimento é necessário utilizar a opção `--group [grupo da dependência]`.

Exemplo:

```bash
# adicionando isort no grupo de dependências dev
poetry add isort --group dev
```